### PR TITLE
Fix "Load more" button text not updating on click

### DIFF
--- a/src/ajaxinate.js
+++ b/src/ajaxinate.js
@@ -158,7 +158,7 @@ Ajaxinate.prototype.loadMore = function getTheHtmlOfTheNextPageWithAnAjaxRequest
       this.initialize();
     }
   }.bind(this);
-  this.request.open("GET", this.nextPageUrl, false);
+  this.request.open("GET", this.nextPageUrl);
   this.request.send();
 };
 


### PR DESCRIPTION
### Issue
For any of our themes that are using this library, the "Load more" button won't update its text on click.

### Solution
Initially, it was found that the button's text was indeed being updated by Ajaxinate, however it wouldn't be rendered in browser. After much searching, @JakeOlney , @alibosworth , and I traced it back to changes made in the commit https://github.com/fluorescent/Ajaxinate/commit/04d3e2515c0372711423d57279ab2fb412a3e870. It looks like the switch to a synchronous request was locking up the page, so this has been undone.

Themes affected by this change are Cornerstone, Stiletto, Spark, and Ira.